### PR TITLE
Removing .npmrc and updating to use public npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@nilfoundation:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -12,7 +12,19 @@ This repository contains In-EVM Mina State verification project.
 - [nodejs](https://nodejs.org/en/) >= 16.0
 - [Ganache CLI](https://github.com/trufflesuite/ganache)
 
-## Compile 
+
+## Clone
+```
+git clone git@github.com:NilFoundation/mina-state-proof.git
+cd mina-state-proof
+```
+
+## Install dependency packagages
+```
+npm i
+```
+
+## Compile contracts 
 ```
 npx hardhat compile
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ git clone git@github.com:NilFoundation/mina-state-proof.git
 cd mina-state-proof
 ```
 
-## Install dependency packagages
+## Install dependency packages
 ```
 npm i
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "Apache",
       "dependencies": {
-        "@nilfoundation/evm-placeholder-verification": "^1.0.10",
         "@openzeppelin/contracts": ">=4.7.2",
         "@truffle/hdwallet-provider": "^2.0.1",
         "as-table": "1.0.55",
@@ -1278,10 +1277,9 @@
     },
     "node_modules/@nilfoundation/evm-placeholder-verification": {
       "version": "1.0.10",
-      "resolved": "https://npm.pkg.github.com/download/@nilfoundation/evm-placeholder-verification/1.0.10/7263eec366d4722ec7ea56f6ef9d157dcf7f6a71",
-      "integrity": "sha512-x2QIMEmqgLc6WeY5WftqO1Yb7SPxe1OiDujZpDI52Bw2Z3AY+u1nJH69FGBE9MkgONOI5+m9Jqff9uGgIKS/Vg==",
+      "resolved": "https://registry.npmjs.org/@nilfoundation/evm-placeholder-verification/-/evm-placeholder-verification-1.0.10.tgz",
+      "integrity": "sha512-G0BfTl1njDEXsKYbfyajLPskE5x+HVB/VExf5UU8Q9EN29B95zilpn+QkCz5twhD20uZ0We9FmtN35is2upRLQ==",
       "dev": true,
-      "license": "Apache",
       "dependencies": {
         "@truffle/hdwallet-provider": "^2.0.1",
         "as-table": "1.0.55",
@@ -13911,8 +13909,8 @@
     },
     "@nilfoundation/evm-placeholder-verification": {
       "version": "1.0.10",
-      "resolved": "https://npm.pkg.github.com/download/@nilfoundation/evm-placeholder-verification/1.0.10/7263eec366d4722ec7ea56f6ef9d157dcf7f6a71",
-      "integrity": "sha512-x2QIMEmqgLc6WeY5WftqO1Yb7SPxe1OiDujZpDI52Bw2Z3AY+u1nJH69FGBE9MkgONOI5+m9Jqff9uGgIKS/Vg==",
+      "resolved": "https://registry.npmjs.org/@nilfoundation/evm-placeholder-verification/-/evm-placeholder-verification-1.0.10.tgz",
+      "integrity": "sha512-G0BfTl1njDEXsKYbfyajLPskE5x+HVB/VExf5UU8Q9EN29B95zilpn+QkCz5twhD20uZ0We9FmtN35is2upRLQ==",
       "dev": true,
       "requires": {
         "@truffle/hdwallet-provider": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,13 @@
   "name": "evm-mina-state",
   "version": "1.0.0",
   "dependencies": {
+    "@openzeppelin/contracts": ">=4.7.2",
     "@truffle/hdwallet-provider": "^2.0.1",
     "as-table": "1.0.55",
     "bip39": "^3.0.4",
     "eth-gas-reporter": "^0.2.24",
     "ethereumjs-wallet": "^1.0.2",
-    "web3": "^1.7.0",
-    "@nilfoundation/evm-placeholder-verification": "^1.0.10",
-    "@openzeppelin/contracts": ">=4.7.2"
+    "web3": "^1.7.0"
   },
   "devDependencies": {
     "@nilfoundation/evm-placeholder-verification": "^1.0.10",


### PR DESCRIPTION
Github npm packages requires user to setup an access token , this causes friction for developers. 
This pull requests removes the dependency on github and adds it via npmjs.